### PR TITLE
Fixed `error: ‘sleep_for’ is not a member of ‘std::this_thread’`

### DIFF
--- a/src/toolchain/Command.cpp
+++ b/src/toolchain/Command.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <unistd.h>
+#include <thread>
 
 #if __linux__
 #include <wait.h>


### PR DESCRIPTION
I was not able to `make` the project and would get the following error
```
home/jshelly/Tester/src/toolchain/Command.cpp: In function ‘void {anonymous}::runCommand(std::promise<unsigned int>&, std::atomic_bool&, const std::string&, const std::vector<std::__cxx11::basic_string<char> >&, const std::string&, const std::string&, const std::string&)’:
/home/jshelly/Tester/src/toolchain/Command.cpp:126:23: error: ‘sleep_for’ is not a member of ‘std::this_thread’
  126 |     std::this_thread::sleep_for(std::chrono::milliseconds(10));
      |                       ^~~~~~~~~
make[2]: *** [src/toolchain/CMakeFiles/toolchain.dir/build.make:76: src/toolchain/CMakeFiles/toolchain.dir/Command.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:396: src/toolchain/CMakeFiles/toolchain.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
It seemed like `sleep_for` was not in the std library, explicitly including it worked. 
I made the pull request as another friend of mine also has the same issue (so I believe others may also face the same issue).
Perhaps this is for arch-based distros where the header is missing in the std lib.