### PR TITLE
handle errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(Tester)
 set(CMAKE_CXX_STANDARD 17)
 
 # Add CXX flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 
 # Include cmake utilities
 include("${CMAKE_SOURCE_DIR}/cmake/symlink_to_bin.cmake")

--- a/include/toolchain/Command.h
+++ b/include/toolchain/Command.h
@@ -60,8 +60,9 @@ private:
   std::vector<std::string> args;
 
   // Output info.
-  bool isStdOut;
   fs::path output;
+  bool isStdOut;
+  fs::path stdoutPath;
 
   // Uses runtime.
   bool usesRuntime;

--- a/include/toolchain/ExecutionState.h
+++ b/include/toolchain/ExecutionState.h
@@ -38,20 +38,23 @@ private:
   fs::path testedRuntime;
 };
 
-// A class meant to share intermediate info when end a toolchain step.
+// A class meant to share intermediate info when a toolchain step ends.
 class ExecutionOutput {
 public:
   // No default constructor.
   ExecutionOutput() = delete;
 
   // Creates output to a subprocess execution.
-  explicit ExecutionOutput(fs::path outputPath) : outputPath(std::move(outputPath)) { }
+  explicit ExecutionOutput(fs::path outputPath, fs::path errorPath = "") :
+      outputPath(std::move(outputPath)), errorPath(std::move(errorPath)) { }
 
   // Gets output file.
   fs::path getOutputFile() const { return outputPath; }
+  fs::path getErrorFile() const { return errorPath; }
 
 private:
   fs::path outputPath;
+  fs::path errorPath;
 };
 
 } // End namespace tester

--- a/src/tests/testRunning.cpp
+++ b/src/tests/testRunning.cpp
@@ -13,10 +13,10 @@
 namespace {
 
 void getFileLines(fs::path fp, std::vector<std::string> &lines) {
-  std::ifstream fs(fp);
-  std::string buf;
-  while (std::getline(fs, buf))
-    lines.push_back(buf);
+    std::ifstream fs(fp);
+    std::string buf;
+    while (std::getline(fs, buf))
+        lines.push_back(buf);
 }
 
 } // End anonymous namespace
@@ -26,34 +26,89 @@ namespace tester {
 
 TestResult runTest(const PathMatch &pm, const ToolChain &toolChain, bool quiet) {
   // Try to build the test. If there's a problem running a command, then we assume failure.
-  fs::path output;
+  ExecutionOutput eo("");
   try {
-    ExecutionOutput eo = toolChain.build(pm.in, pm.inStream);
-    output = eo.getOutputFile();
+      eo = toolChain.build(pm.in, pm.inStream);
   }
   catch (const CommandException &ce) {
-    if (!quiet)
-      std::cout << "Command error: " << ce.what() << '\n';
-    return TestResult(pm.in, false, true, "");
+      if (!quiet) {
+          std::cout << "Command error: " << ce.what() << '\n';
+          std::cout << "output " << eo.getOutputFile() << std::endl;
+      }
+      return TestResult(pm.in, false, true, "");
   }
 
-  // Get the lines from the files.
+  // Get the lines from the reference file.
   std::vector<std::string> expLines;
-  std::vector<std::string> genLines;
   getFileLines(pm.out, expLines);
-  getFileLines(output, genLines);
 
-  dtl::Diff<std::string> diff(expLines, genLines);
-  diff.compose();
-  diff.composeUnifiedHunks();
-
-  // We failed the test.
-  if (!diff.getUniHunks().empty()) {
-    std::stringstream ss;
-    diff.printUnifiedFormat(ss);
-    return TestResult(pm.in, false, false, ss.str());
+  /* Check to see if this an error test. The error message doesn't have to be
+   * first or only line of output (e.g. a runtime error). However, we are
+   * currently restricting ourselves to the first error in the reference.
+   */
+  std::string refError;
+  for (auto &line: expLines) {
+      if (line.find("Error") != std::string::npos) {
+          refError = line.substr(0, line.find(":")); 
+          break;
+      }
   }
 
+  // Get the lines from the output file.
+  std::vector<std::string> genLines;
+
+  if (refError.empty()) { // Not an error test
+      getFileLines(eo.getOutputFile(), genLines);
+
+      dtl::Diff<std::string> diff(expLines, genLines);
+      diff.compose();
+      diff.composeUnifiedHunks();
+
+      // We failed the test.
+      if (!diff.getUniHunks().empty()) {
+          std::stringstream ss;
+          diff.printUnifiedFormat(ss);
+          return TestResult(pm.in, false, false, ss.str());
+      }
+  }
+  else { // error test
+      getFileLines(eo.getErrorFile(), genLines);
+      std::string genError;
+      for (auto &line: genLines) {
+          if (line.find("Error") != std::string::npos) {
+              genError = line.substr(0, line.find(":")); 
+              break;
+          }
+      }
+
+      /* The size check is partially to avoid overflowing the filler, but also
+       * in case the generated error message does not include the ':' token.
+       */
+      if (!genError.empty() && genError.size()<128) {
+          int refErrLine, genErrLine;
+          char filler[128];
+
+          if (sscanf(refError.c_str(), "Error %s %d", filler, &refErrLine) != 2) {
+              // Ill-formed reference string. Consider this an error.
+              std::cerr << "Hmm, failed to parse ref error line?" << std::endl;
+              return TestResult(pm.in, false, true, refError);
+          }
+          if (sscanf(genError.c_str(), "Error %s %d", filler, &genErrLine) != 2) {
+              // Ill-formed generated error string. Consider this a fail.
+              std::cerr << "Failed to parse generated error line" << std::endl;
+              return TestResult(pm.in, false, false, genError);
+          }
+          if (refErrLine != genErrLine) {
+              // Wrong line number. Is there room here for lee-way?
+              std::string diff = refError + "\n-----------------\n" + genError;
+              std::cerr << "Error lines differ: " << refErrLine << " != "
+                        << genErrLine  << std::endl;
+              return TestResult(pm.in, false, false, diff);
+          }
+      }
+              
+  }
+      
   return TestResult(pm.in, true, false, "");
 }
 


### PR DESCRIPTION
If the reference file has "Error" in it, look for a matching line in the generated files. For compiler errors we have to capture stderr and stop the pipeline; run-time errors also go to stderr so we dup it onto stdout.
