### PR TITLE
fix: failed to make due to const

### DIFF
--- a/include/dtl/Diff.hpp
+++ b/include/dtl/Diff.hpp
@@ -162,7 +162,7 @@ namespace dtl {
             return trivial;
         }
         
-        void enableTrivial () const {
+        void enableTrivial () {
             this->trivial = true;
         }
         


### PR DESCRIPTION
Running 'cmake .. && make' failed with error
...
/home/jj/antlr/Tester/include/dtl/Diff.hpp:166:27: error: assignment of member ‘trivial’ in read-only object
  166 |             this->trivial = true;
      |             ~~~~~~~~~~~~~~^~~~~~
make[2]: *** [src/tests/CMakeFiles/tests.dir/build.make:76: src/tests/CMakeFiles/tests.dir/TestRunning.cpp.o] Error 1
...

Don't know much about C++ but it seems like declaring this method as const prevents the class from altering its field.
Removing const from the method declaration lets me compile it with make.