### PR TITLE
Bump dtl version to fix compile issues.

### DIFF
--- a/include/dtl/Diff.hpp
+++ b/include/dtl/Diff.hpp
@@ -67,6 +67,8 @@ namespace dtl {
         bool               editDistanceOnly;
         uniHunkVec         uniHunks;
         comparator         cmp;
+        long long          ox;
+        long long          oy;
     public :
         Diff () {}
         
@@ -162,7 +164,7 @@ namespace dtl {
             return trivial;
         }
         
-        void enableTrivial () const {
+        void enableTrivial () {
             this->trivial = true;
         }
         
@@ -260,7 +262,8 @@ namespace dtl {
             if (isHuge()) {
                 pathCordinates.reserve(MAX_CORDINATES_SIZE);
             }
-            
+            ox = 0;
+            oy = 0;
             long long p = -1;
             fp = new long long[M + N + 3];
             fill(&fp[0], &fp[M + N + 3], -1);
@@ -339,6 +342,15 @@ namespace dtl {
         void printSES (stream& out) const {
             sesElemVec ses_v = ses.getSequence ();
             for_each (ses_v.begin (), ses_v.end(), PT < sesElem, stream > (out));
+        }
+
+        /**
+         * store difference between A and B as an SES with custom storage
+         */
+        template < typename storedData, template < typename SEET, typename STRT > class ST >
+        void storeSES(storedData& sd) const {
+            sesElemVec ses_v = ses.getSequence();
+            for_each(ses_v.begin(), ses_v.end(), ST < sesElem, storedData >(sd));
         }
         
         /**
@@ -586,18 +598,18 @@ namespace dtl {
                 while(px_idx < v[i].x || py_idx < v[i].y) {
                     if (v[i].y - v[i].x > py_idx - px_idx) {
                         if (!wasSwapped()) {
-                            ses.addSequence(*y, 0, y_idx, SES_ADD);
+                            ses.addSequence(*y, 0, y_idx + oy, SES_ADD);
                         } else {
-                            ses.addSequence(*y, y_idx, 0, SES_DELETE);
+                            ses.addSequence(*y, y_idx + oy, 0, SES_DELETE);
                         }
                         ++y;
                         ++y_idx;
                         ++py_idx;
                     } else if (v[i].y - v[i].x < py_idx - px_idx) {
                         if (!wasSwapped()) {
-                            ses.addSequence(*x, x_idx, 0, SES_DELETE);
+                            ses.addSequence(*x, x_idx + ox, 0, SES_DELETE);
                         } else {
-                            ses.addSequence(*x, 0, x_idx, SES_ADD);
+                            ses.addSequence(*x, 0, x_idx + ox, SES_ADD);
                         }
                         ++x;
                         ++x_idx;
@@ -605,10 +617,10 @@ namespace dtl {
                     } else {
                         if (!wasSwapped()) {
                             lcs.addSequence(*x);
-                            ses.addSequence(*x, x_idx, y_idx, SES_COMMON);
+                            ses.addSequence(*x, x_idx + ox, y_idx + oy, SES_COMMON);
                         } else {
                             lcs.addSequence(*y);
-                            ses.addSequence(*y, y_idx, x_idx, SES_COMMON);
+                            ses.addSequence(*y, y_idx + oy, x_idx + ox, SES_COMMON);
                         }
                         ++x;
                         ++y;
@@ -649,6 +661,8 @@ namespace dtl {
                 fp = new long long[M + N + 3];
                 fill(&fp[0], &fp[M + N + 3], -1);
                 fill(path.begin(), path.end(), -1);
+                ox = x_idx - 1;
+                oy = y_idx - 1;
                 return false;
             }
             return true;

--- a/include/dtl/functors.hpp
+++ b/include/dtl/functors.hpp
@@ -118,6 +118,20 @@ namespace dtl {
     private :
         stream& out_;
     };
+
+    /**
+     * storage class template
+     */
+    template <typename sesElem, typename storedData >
+    class Storage
+    {
+    public:
+        Storage(storedData& sd) : storedData_(sd) {}
+        virtual ~Storage() {}
+        virtual void operator() (const sesElem& se) const = 0;
+    protected:
+        storedData& storedData_;
+    };
     
     /**
      * compare class template

--- a/include/dtl/variables.hpp
+++ b/include/dtl/variables.hpp
@@ -63,7 +63,7 @@ namespace dtl {
     /**
      * version string
      */
-    const string version = "1.19";
+    const string version = "1.21";
 
     /**
      * type of edit for SES


### PR DESCRIPTION
Bump version of dtl diff library. Not really actually anything crazy here. Most of the files haven't been touched in 8 years, but the relevant stuff has. Files are API compatible, Diff3 wasn't even touched, just Diff and two files we don't outwardly use.

Closes #44.