### PR TITLE
Put intermediate toolchain files in cwd rather than tmp

### DIFF
--- a/src/analysis/Grader.cpp
+++ b/src/analysis/Grader.cpp
@@ -136,9 +136,8 @@ void Grader::fillToolchainResultsJSON() {
               }
               trackSolutionFailure(test.get(), toolChain.first, attacker);
             }
-            //  
             if (result.pass) {
-              testCount++;
+              passCount++;
             }
             // Print the test result in a nice to read format.
             printGraderTestResult(result.pass, result.error);

--- a/src/toolchain/Command.cpp
+++ b/src/toolchain/Command.cpp
@@ -185,10 +185,9 @@ Command::Command(const JSON& step, int64_t timeout)
     args.push_back(arg);
 
   // If no output path is supplied by default, temporaries are created to capture stdout and stderr.
-  std::string output_name = std::string(step["stepName"]) + ".stdout";
-  std::string error_name = std::string(step["stepName"]) + ".stderr";
-  outPath = fs::temp_directory_path() / output_name;
-  errPath = fs::temp_directory_path() / error_name;
+  const auto& stepName = step["stepName"];
+  outPath = fs::path(stepName).replace_extension(".stdout");
+  errPath = fs::path(stepName).replace_extension(".stderr");  
 
   // Set the executable path
   std::string path = step["executablePath"];


### PR DESCRIPTION
This is the simplest fix for the `dup2` errors students were frequently getting when the intermediate files were created in `/tmp`.

Ayrton and I have been discussing some more elaborate redesigns for the Tester. While those plans are in development this should be sufficient.