### PR TITLE
Tests now fail when failing to create output

### DIFF
--- a/src/tests/TestRunning.cpp
+++ b/src/tests/TestRunning.cpp
@@ -3,6 +3,7 @@
 #include "Colors.h"
 #include "config/Config.h"
 #include "dtl/dtl.hpp"
+#include "tests/TestResult.h"
 #include "toolchain/CommandException.h"
 #include "toolchain/ExecutionState.h"
 #include <optional>
@@ -213,7 +214,7 @@ TestResult runTest(TestFile* test, const ToolChain& toolChain, const Config& cfg
     }
 
     // Check if we were able to create the output file
-    std::ifstream file(genErrorString);
+    std::ifstream file(genOutPath);
     if (!file.is_open()) {
       return TestResult(testPath, false, true, "Failed to create output file");
     }

--- a/src/tests/TestRunning.cpp
+++ b/src/tests/TestRunning.cpp
@@ -212,6 +212,12 @@ TestResult runTest(TestFile* test, const ToolChain& toolChain, const Config& cfg
       genOutPath = eo.getOutputFile();
     }
 
+    // Check if we were able to create the output file
+    std::ifstream file(genErrorString);
+    if (!file.is_open()) {
+      return TestResult(testPath, false, true, "Failed to create output file");
+    }
+
   } catch (const CommandException& ce) {
     // toolchain throws errors only when allowError is false in the config
     if (cfg.getVerbosity() > 0) {


### PR DESCRIPTION
We previously failed to check that the output files were created by the student binary before issuing a pass/fail for the test. This resulted in false passes for binaries that did not print to an ofstream.

This patch fixes this issue by checking if the file is created and failing if it is not.